### PR TITLE
Added outbound mobility handbook and faq to doc_options

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -35,11 +35,11 @@ language_detection_chain = (
     | StrOutputParser()
 )
 
-doc_options = ["BUV Frequently Asked Questions", "SU Frequently Asked Questions", "Student Handbook", "PSG Programme Handbook"]
+doc_options = ["BUV Frequently Asked Questions", "SU Frequently Asked Questions", "Student Handbook", "PSG Programme Handbook", "Outbound Mobility Handbook & FAQ"]
 class FormatedOutput(BaseModel):
     answer: str = Field(description="The answer to the user question")
     # source: Optional[Literal[*np.array(doc_options)]] = Field(description=f"Source document of the information retrieved, should be one of these options: {doc_options}") #type:ignore
-    source: Optional[Literal["BUV Frequently Asked Questions", "SU Frequently Asked Questions", "Student Handbook", "PSG Programme Handbook"]] = Field(default=None, description=f"Source document of the information retrieved, should be one of these options: {doc_options}") #type:ignore
+    source: Optional[Literal["BUV Frequently Asked Questions", "SU Frequently Asked Questions", "Student Handbook", "PSG Programme Handbook", "Outbound Mobility Handbook & FAQ"]] = Field(default=None, description=f"Source document of the information retrieved, should be one of these options: {doc_options}") #type:ignore
     page_number: Optional[str] = Field(default=None, description="The page number in the document where the information was retrieved")
 
 def stringify_formatted_answer(inputs: FormatedOutput) -> str:


### PR DESCRIPTION
**Title:** Handling a new document named "Outbound Mobility Handbook & FAQ"

**Description:**  
- Adding "Outbound Mobility Handbook & FAQ" into `doc_options`
- Necessary because "Outbound Mobility Handbook & FAQ" is a new document

**Checklist:**  
- [ ] Code follows style guidelines.  
- [ ] Documentation updated if needed.  
- [x] Tests added/updated.  
- [x] Code tested locally.

**Changes Made:**  
- Modifying `doc_options` to handle "Outbound Mobility Handbook & FAQ"

**Testing:**  
- Call a GET request. E.g. For SU bot, `http://localhost:8000/su/new_session_id`
- After getting a new id, call a POST request. E.g. `http://localhost:8000/su`
E.g. JSON content of a POST request `{
    "message": "Currently available Outbound mobility programmes at BUV",
    "session_id": 1359
}`

**Related Issues:**  
- Closes #[issue number]

**Additional Notes:**  
